### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Model Context Protocol (MCP) is a technology that allows AI assistants like Clau
 
 This MCP server connects Claude, Cursor, or other compatible AI assistants with your Bitbucket instance, allowing them to list repositories, access pull requests, and view commit information.
 
+<a href="https://glama.ai/mcp/servers/@aashari/mcp-server-atlassian-bitbucket">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aashari/mcp-server-atlassian-bitbucket/badge" alt="Atlassian Bitbucket Server MCP server" />
+</a>
+
 ## Quick Start Guide
 
 ### Step 1: Set Up Authentication


### PR DESCRIPTION
This PR adds a badge for the [Atlassian Bitbucket MCP Server](https://glama.ai/mcp/servers/@aashari/mcp-server-atlassian-bitbucket) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@aashari/mcp-server-atlassian-bitbucket">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aashari/mcp-server-atlassian-bitbucket/badge" alt="Atlassian Bitbucket Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.