### PR TITLE
Add Create Pull Request Feature

### DIFF
--- a/src/cli/atlassian.pullrequests.cli.ts
+++ b/src/cli/atlassian.pullrequests.cli.ts
@@ -33,15 +33,15 @@ interface PullRequestControllerOptions {
  */
 function registerCreatePullRequestCommand(program: Command): void {
 	program
-		.command('create-pr')
+		.command('create-pull-request')
 		.description(
 			`Create a new pull request in a Bitbucket repository.
 
     PURPOSE: Create a new pull request from one branch to another within a repository.
 
     EXAMPLES:
-    $ mcp-atlassian-bitbucket create-pr -w workspace-slug -r repo-slug -t "New feature" -s feature/branch -d main
-    $ mcp-atlassian-bitbucket create-pr -w workspace-slug -r repo-slug -t "Bug fix" -s bugfix/issue-123 -d develop --desc "This fixes issue #123" --close-source`,
+    $ mcp-atlassian-bitbucket create-pull-request -w workspace-slug -r repo-slug -t "New feature" -s feature/branch -d main
+    $ mcp-atlassian-bitbucket create-pull-request -w workspace-slug -r repo-slug -t "Bug fix" -s bugfix/issue-123 -d develop --description "This fixes issue #123" --close-source-branch`,
 		)
 		.requiredOption(
 			'-w, --workspace-slug <slug>',
@@ -60,16 +60,16 @@ function registerCreatePullRequestCommand(program: Command): void {
 			'-d, --destination-branch <branch>',
 			'Destination branch name (the branch you want to merge into, defaults to main)',
 		)
-		.option('--desc <description>', 'Description for the pull request')
+		.option('--description <text>', 'Description for the pull request')
 		.option(
-			'--close-source',
+			'--close-source-branch',
 			'Close source branch after pull request is merged',
 			false,
 		)
 		.action(async (options) => {
 			const actionLogger = Logger.forContext(
 				'cli/atlassian.pullrequests.cli.ts',
-				'create-pr',
+				'create-pull-request',
 			);
 			try {
 				actionLogger.debug('Processing command options:', options);
@@ -81,8 +81,8 @@ function registerCreatePullRequestCommand(program: Command): void {
 					title: options.title,
 					sourceBranch: options.sourceBranch,
 					destinationBranch: options.destinationBranch,
-					description: options.desc,
-					closeSourceBranch: options.closeSource,
+					description: options.description,
+					closeSourceBranch: options.closeSourceBranch,
 				});
 
 				console.log(result.content);

--- a/src/controllers/atlassian.pullrequests.controller.ts
+++ b/src/controllers/atlassian.pullrequests.controller.ts
@@ -12,6 +12,7 @@ import {
 	PullRequestIdentifier,
 	ListPullRequestCommentsOptions,
 	AddPullRequestCommentOptions,
+	CreatePullRequestOptions,
 } from './atlassian.pullrequests.types.js';
 import {
 	formatPullRequestsList,
@@ -26,6 +27,7 @@ import {
 import { formatBitbucketQuery } from '../utils/query.util.js';
 import { DEFAULT_PAGE_SIZE, applyDefaults } from '../utils/defaults.util.js';
 import { AddPullRequestCommentParams } from '../services/vendor.atlassian.pullrequests.types.js';
+import { CreatePullRequestParams } from '../services/vendor.atlassian.pullrequests.types.js';
 
 /**
  * Controller for managing Bitbucket pull requests.
@@ -368,4 +370,92 @@ async function addComment(
 	}
 }
 
-export default { list, get, listComments, addComment };
+/**
+ * Create a new pull request
+ * @param options - Options for creating a new pull request
+ * @param options.workspaceSlug - Workspace slug containing the repository
+ * @param options.repoSlug - Repository slug to create the pull request in
+ * @param options.title - Title of the pull request
+ * @param options.sourceBranch - Source branch name
+ * @param options.destinationBranch - Destination branch name (defaults to the repository's main branch)
+ * @param options.description - Optional description for the pull request
+ * @param options.closeSourceBranch - Whether to close the source branch after merge
+ * @returns Promise with formatted pull request details content
+ */
+async function create(
+	options: CreatePullRequestOptions,
+): Promise<ControllerResponse> {
+	const methodLogger = Logger.forContext(
+		'controllers/atlassian.pullrequests.controller.ts',
+		'create',
+	);
+	methodLogger.debug('Creating new pull request...', options);
+
+	try {
+		if (!options.workspaceSlug || !options.repoSlug) {
+			throw createApiError(
+				'workspaceSlug and repoSlug parameters are required',
+			);
+		}
+
+		if (!options.title) {
+			throw createApiError('Pull request title is required');
+		}
+
+		if (!options.sourceBranch) {
+			throw createApiError('Source branch is required');
+		}
+
+		// The API requires a destination branch, use default if not provided
+		const destinationBranch = options.destinationBranch || 'main';
+
+		// Map controller options to service params
+		const serviceParams: CreatePullRequestParams = {
+			workspace: options.workspaceSlug,
+			repo_slug: options.repoSlug,
+			title: options.title,
+			source: {
+				branch: {
+					name: options.sourceBranch,
+				},
+			},
+			destination: {
+				branch: {
+					name: destinationBranch,
+				},
+			},
+		};
+
+		// Add optional parameters if provided
+		if (options.description) {
+			serviceParams.description = options.description;
+		}
+
+		if (options.closeSourceBranch !== undefined) {
+			serviceParams.close_source_branch = options.closeSourceBranch;
+		}
+
+		// Call the service to create the pull request
+		const pullRequest =
+			await atlassianPullRequestsService.create(serviceParams);
+
+		// Format the created pull request details for response
+		return {
+			content: formatPullRequestDetails(pullRequest),
+		};
+	} catch (error) {
+		throw handleControllerError(error, {
+			entityType: 'pull-request',
+			operation: 'create',
+			source: 'controllers/atlassian.pullrequests.controller.ts',
+		});
+	}
+}
+
+export default {
+	list,
+	get,
+	listComments,
+	addComment,
+	create,
+};

--- a/src/controllers/atlassian.pullrequests.types.ts
+++ b/src/controllers/atlassian.pullrequests.types.ts
@@ -114,3 +114,43 @@ export interface AddPullRequestCommentOptions {
 		line: number;
 	};
 }
+
+/**
+ * Options for creating a new pull request
+ */
+export interface CreatePullRequestOptions {
+	/**
+	 * Workspace slug containing the repository
+	 */
+	workspaceSlug: string;
+
+	/**
+	 * Repository slug to create the pull request in
+	 */
+	repoSlug: string;
+
+	/**
+	 * Title of the pull request
+	 */
+	title: string;
+
+	/**
+	 * Source branch name
+	 */
+	sourceBranch: string;
+
+	/**
+	 * Destination branch name (defaults to the repository's main branch)
+	 */
+	destinationBranch?: string;
+
+	/**
+	 * Optional description for the pull request
+	 */
+	description?: string;
+
+	/**
+	 * Whether to close the source branch after merge
+	 */
+	closeSourceBranch?: boolean;
+}

--- a/src/services/vendor.atlassian.pullrequests.types.ts
+++ b/src/services/vendor.atlassian.pullrequests.types.ts
@@ -364,3 +364,51 @@ export interface PullRequestCommentsResponse {
 		title?: string;
 	};
 }
+
+/**
+ * Parameters for creating a pull request
+ */
+export interface CreatePullRequestParams {
+	/**
+	 * The workspace slug or UUID
+	 */
+	workspace: string;
+
+	/**
+	 * The repository slug or UUID
+	 */
+	repo_slug: string;
+
+	/**
+	 * Title of the pull request
+	 */
+	title: string;
+
+	/**
+	 * Source branch information
+	 */
+	source: {
+		branch: {
+			name: string;
+		};
+	};
+
+	/**
+	 * Destination branch information
+	 */
+	destination: {
+		branch: {
+			name: string;
+		};
+	};
+
+	/**
+	 * Optional description for the pull request
+	 */
+	description?: string;
+
+	/**
+	 * Whether to close the source branch after merge
+	 */
+	close_source_branch?: boolean;
+}

--- a/src/tools/atlassian.pullrequests.types.ts
+++ b/src/tools/atlassian.pullrequests.types.ts
@@ -231,3 +231,78 @@ export const AddPullRequestCommentToolArgs = z.object({
 export type AddPullRequestCommentToolArgsType = z.infer<
 	typeof AddPullRequestCommentToolArgs
 >;
+
+/**
+ * Arguments schema for the pull_requests_create tool
+ */
+export const CreatePullRequestToolArgs = z.object({
+	/**
+	 * Workspace slug containing the repository
+	 */
+	workspaceSlug: z
+		.string()
+		.min(1, 'Workspace slug is required')
+		.describe(
+			'Workspace slug containing the repository. Must be a valid workspace slug from your Bitbucket account. Example: "myteam"',
+		),
+
+	/**
+	 * Repository slug to create the pull request in
+	 */
+	repoSlug: z
+		.string()
+		.min(1, 'Repository slug is required')
+		.describe(
+			'Repository slug to create the pull request in. This must be a valid repository in the specified workspace. Example: "project-api"',
+		),
+
+	/**
+	 * Title of the pull request
+	 */
+	title: z
+		.string()
+		.min(1, 'Pull request title is required')
+		.describe('Title for the pull request. Example: "Add new feature"'),
+
+	/**
+	 * Source branch name
+	 */
+	sourceBranch: z
+		.string()
+		.min(1, 'Source branch name is required')
+		.describe(
+			'Source branch name (the branch containing your changes). Example: "feature/new-login"',
+		),
+
+	/**
+	 * Destination branch name
+	 */
+	destinationBranch: z
+		.string()
+		.optional()
+		.describe(
+			'Destination branch name (the branch you want to merge into, defaults to main). Example: "develop"',
+		),
+
+	/**
+	 * Description for the pull request
+	 */
+	description: z
+		.string()
+		.optional()
+		.describe('Optional description for the pull request.'),
+
+	/**
+	 * Whether to close the source branch after merge
+	 */
+	closeSourceBranch: z
+		.boolean()
+		.optional()
+		.describe(
+			'Whether to close the source branch after the pull request is merged. Default: false',
+		),
+});
+
+export type CreatePullRequestToolArgsType = z.infer<
+	typeof CreatePullRequestToolArgs
+>;


### PR DESCRIPTION
# Add Create Pull Request Feature

## Changes
This PR adds a new feature to create pull requests through both CLI and MCP tools.

## Implementation Details
- Added service layer function to call Bitbucket API for PR creation
- Added controller logic to handle business rules
- Added CLI command `create-pr` with required and optional parameters
- Added MCP tool `pull_requests_create` for AI integration

## Features
- Create PRs with required parameters (workspace, repo, title, source branch)
- Support optional parameters:
  - Destination branch (defaults to main)
  - Description
  - Close source branch toggle

## Testing
The feature has been manually tested by creating a real PR in the codapayments/coda-log repository.

## Related Issue
Closes #3

## Screenshots
N/A
