### PR TITLE
feat: add support for threaded comments in pull request comments

### DIFF
--- a/src/controllers/atlassian.pullrequests.base.controller.ts
+++ b/src/controllers/atlassian.pullrequests.base.controller.ts
@@ -64,6 +64,9 @@ export type CreateCommentParams = {
 		path: string;
 		to?: number;
 	};
+	parent?: {
+		id: number;
+	};
 };
 
 // Helper function to enhance comments with code snippets

--- a/src/controllers/atlassian.pullrequests.comments.controller.ts
+++ b/src/controllers/atlassian.pullrequests.comments.controller.ts
@@ -230,6 +230,13 @@ async function addComment(
 			};
 		}
 
+		// For replies, add the parent property
+		if (mergedOptions.parentId) {
+			serviceParams.parent = {
+				id: parseInt(mergedOptions.parentId, 10),
+			};
+		}
+
 		// Create the comment through the service
 		const commentResult =
 			await atlassianPullRequestsService.createComment(serviceParams);

--- a/src/services/vendor.atlassian.pullrequests.service.ts
+++ b/src/services/vendor.atlassian.pullrequests.service.ts
@@ -335,6 +335,7 @@ async function createComment(
 		body: {
 			content: params.content,
 			inline: params.inline,
+			parent: params.parent,
 		},
 	});
 }

--- a/src/services/vendor.atlassian.pullrequests.types.ts
+++ b/src/services/vendor.atlassian.pullrequests.types.ts
@@ -229,6 +229,13 @@ export interface CreatePullRequestCommentParams {
 		 */
 		to?: number;
 	};
+
+	/**
+	 * For threaded comments, ID of the parent comment
+	 */
+	parent?: {
+		id: number;
+	};
 }
 
 /**

--- a/src/tools/atlassian.pullrequests.tool.ts
+++ b/src/tools/atlassian.pullrequests.tool.ts
@@ -390,7 +390,7 @@ function registerTools(server: McpServer) {
 	// Register the add pull request comment tool
 	server.tool(
 		'bb_add_pr_comment',
-		`Adds a comment to a specific pull request identified by \`prId\` within a repository (\`repoSlug\`). If \`workspaceSlug\` is not provided, the system will use your default workspace. The \`content\` parameter accepts Markdown-formatted text for the comment body. For inline code comments, provide both \`inline.path\` (file path) and \`inline.line\` (line number). Returns a success message as formatted Markdown. Requires Bitbucket credentials with write permissions to be configured.`,
+		`Adds a comment to a specific pull request identified by \`prId\` within a repository (\`repoSlug\`). If \`workspaceSlug\` is not provided, the system will use your default workspace. The \`content\` parameter accepts Markdown-formatted text for the comment body. To reply to an existing comment, provide its ID in the \`parentId\` parameter. For inline code comments, provide both \`inline.path\` (file path) and \`inline.line\` (line number). Returns a success message as formatted Markdown. Requires Bitbucket credentials with write permissions to be configured.`,
 		CreatePullRequestCommentToolArgs.shape,
 		addPullRequestComment,
 	);

--- a/src/tools/atlassian.pullrequests.types.ts
+++ b/src/tools/atlassian.pullrequests.types.ts
@@ -242,6 +242,13 @@ export const CreatePullRequestCommentToolArgs = z.object({
 		.describe(
 			'Optional inline location for the comment. If provided, this will create a comment on a specific line in a file.',
 		),
+
+	parentId: z
+		.string()
+		.optional()
+		.describe(
+			'The ID of the parent comment to reply to. If not provided, the comment will be a top-level comment.',
+		),
 });
 
 export type CreatePullRequestCommentToolArgsType = z.infer<


### PR DESCRIPTION
Enhance the comment functionality by introducing a parent property for threaded comments. This allows users to reply to existing comments by specifying the parent comment ID. Updates include:

- Added `parent` property to `CreateCommentParams` and related types.
- Modified `addComment` function to handle parent comment ID.
- Updated service layer to include parent comment information in the comment creation process.
- Enhanced tool documentation to reflect the new `parentId` parameter for replies.

This feature improves the user experience by enabling more organized discussions within pull requests.