### PR TITLE
fix: Use single baseUrl for auth with user-pass or token

### DIFF
--- a/src/utils/transport.util.ts
+++ b/src/utils/transport.util.ts
@@ -99,14 +99,13 @@ export async function fetchAtlassian<T>(
 		'utils/transport.util.ts',
 		'fetchAtlassian',
 	);
+	const baseUrl = 'https://api.bitbucket.org';
 
-	// Set up base URL and auth headers based on credential type
-	let baseUrl: string;
+	// Set up auth headers based on credential type
 	let authHeader: string;
 
 	if (credentials.useBitbucketAuth) {
-		// Bitbucket API uses a different base URL and auth format
-		baseUrl = 'https://api.bitbucket.org';
+		// Bitbucket API uses a different auth format
 		if (
 			!credentials.bitbucketUsername ||
 			!credentials.bitbucketAppPassword
@@ -120,14 +119,11 @@ export async function fetchAtlassian<T>(
 		).toString('base64')}`;
 	} else {
 		// Standard Atlassian API (Jira, Confluence)
-		if (
-			!credentials.siteName ||
-			!credentials.userEmail ||
+		if (!credentials.userEmail ||
 			!credentials.apiToken
 		) {
 			throw createAuthInvalidError('Missing Atlassian credentials');
 		}
-		baseUrl = `https://${credentials.siteName}.atlassian.net`;
 		authHeader = `Basic ${Buffer.from(
 			`${credentials.userEmail}:${credentials.apiToken}`,
 		).toString('base64')}`;


### PR DESCRIPTION
This PR fixes issue #61 