### PR TITLE
fix: Prevent dotenv from outputting to STDIO in MCP mode

### DIFF
--- a/src/utils/config.util.ts
+++ b/src/utils/config.util.ts
@@ -56,7 +56,9 @@ class ConfigLoader {
 			'loadFromEnvFile',
 		);
 		try {
-			const result = dotenv.config();
+			// Use quiet mode to prevent dotenv from outputting to STDIO
+			// which interferes with MCP's JSON-RPC communication
+			const result = dotenv.config({ quiet: true });
 			if (result.error) {
 				methodLogger.debug('No .env file found or error reading it');
 				return;


### PR DESCRIPTION
## Problem
The `dotenv.config()` call in `src/utils/config.util.ts` was outputting log messages to STDIO, which interfered with MCP's JSON-RPC communication in Claude Desktop. This caused "Unexpected token" JSON parsing errors.

**Error message:**
```
Unexpected token 'd', "[dotenv@17."... is not valid JSON
```

**Root cause:** 
dotenv was outputting messages like `[dotenv@17.2.2] injecting env (0) from .env` to STDIO, which broke the JSON-RPC protocol used by MCP servers.

## Solution
Added `{ quiet: true }` option to `dotenv.config()` call to suppress these log messages.

**Changes:**
- Modified `src/utils/config.util.ts` line 61
- Added explanatory comment
- No functional changes to environment variable loading behavior

## Testing
- ✅ Local testing confirms dotenv messages are suppressed
- ✅ MCP server starts and operates normally
- ✅ Bitbucket API calls work correctly
- ✅ No regression in environment variable loading

## Impact
This fix resolves STDIO interference for all Claude Desktop users without requiring any configuration changes on their part.

Fixes JSON parsing errors in MCP STDIO transport mode.