### PR TITLE
Fix: Only set Content-Type header when request body is present

### DIFF
--- a/src/utils/transport.util.ts
+++ b/src/utils/transport.util.ts
@@ -137,12 +137,17 @@ export async function fetchAtlassian<T>(
 	const url = `${baseUrl}${normalizedPath}`;
 
 	// Set up authentication and headers
-	const headers = {
+	const headers: Record<string, string> = {
 		Authorization: authHeader,
-		'Content-Type': 'application/json',
 		Accept: 'application/json',
 		...options.headers,
 	};
+
+	// Only set Content-Type when there's a request body
+	// Bitbucket API rejects POST requests with Content-Type but no body (returns 400)
+	if (options.body) {
+		headers['Content-Type'] = 'application/json';
+	}
 
 	// Prepare request options
 	const requestOptions: RequestInit = {


### PR DESCRIPTION
## Description

Fixes #181

This PR resolves the issue where `bb_approve_pr` and `bb_reject_pr` tools fail with 400 Bad Request errors.

## Root Cause

The Bitbucket API rejects POST requests that include `Content-Type: application/json` header but have no request body, returning 400 Bad Request. The `fetchAtlassian` function was unconditionally setting this header for all requests.

## Changes

- Modified `fetchAtlassian()` in `src/utils/transport.util.ts` to only add Content-Type header when `options.body` is present
- Added explanatory comment about Bitbucket API behavior
- Made headers declaration explicit with `Record<string, string>` type

## Testing

Verified the fix resolves the following scenarios:
- ✅ POST without body (approve PR) - now works correctly
- ✅ POST with body (add comment) - continues to work
- ✅ GET requests - continues to work

## Before
```typescript
const headers = {
	Authorization: authHeader,
	'Content-Type': 'application/json',  // Always set
	Accept: 'application/json',
	...options.headers,
};
```

## After
```typescript
const headers: Record<string, string> = {
	Authorization: authHeader,
	Accept: 'application/json',
	...options.headers,
};

// Only set Content-Type when there's a request body
if (options.body) {
	headers['Content-Type'] = 'application/json';
}
```

## Impact

This fix affects all POST requests without a body, specifically:
- `bb_approve_pr` ✅ (now fixed)
- `bb_reject_pr` ✅ (now fixed)
- Existing tools with request bodies remain unaffected